### PR TITLE
Notify user when copy icon is disabled

### DIFF
--- a/app/components/styleditor/tools/icons.js
+++ b/app/components/styleditor/tools/icons.js
@@ -100,17 +100,32 @@ angular.module('gsApp.styleditor.icons', [
         });
       };
 
+      $scope.hasFlash = false;
       $timeout(function() {
-        new ZeroClipboard($('#copyIcon')).on('copy',
-          function(event) {
-            var clipboard = event.clipboardData;
-            if ($scope.selectedIconName) {
-              clipboard.setData('text/plain',
-                $scope.selectedIconPath
-              );
-              $scope.close();
+        try {
+            var swf = new ActiveXObject('ShockwaveFlash.ShockwaveFlash');
+            if (swf) {
+                $scope.hasFlash = true;
             }
-          });
+        } catch (e) {
+            if (navigator.mimeTypes
+                && navigator.mimeTypes['application/x-shockwave-flash'] != undefined
+                && navigator.mimeTypes['application/x-shockwave-flash'].enabledPlugin) {
+              $scope.hasFlash = true;
+            }
+        }
+        if ($scope.hasFlash) {
+            new ZeroClipboard($('#copyIcon')).on('copy',
+              function(event) {
+                var clipboard = event.clipboardData;
+                if ($scope.selectedIconName) {
+                  clipboard.setData('text/plain',
+                    $scope.selectedIconPath
+                  );
+                  $scope.close();
+                }
+              });
+        }
       }, 500);
 
     }]);

--- a/app/components/styleditor/tools/icons.less
+++ b/app/components/styleditor/tools/icons.less
@@ -4,6 +4,21 @@
 button#copyIcon {
   margin-right: 20px;
 }
+button#copyDisabled {
+  //Fake disabled style so that we still trigger mouseover for the popover
+  cursor: not-allowed;
+  -moz-opacity: 0.65;
+  -khtml-opacity: 0.65;
+  -webkit-opacity: 0.65;
+  -ms-filter: progid:DXImageTransform.Microsoft.Alpha(opacity=65);
+  opacity: 0.65;
+  filter: alpha(opacity=65);
+  -moz-box-shadow: none;
+  -webkit-box-shadow: none;
+  box-shadow: none;
+  background-color: #f0ad4e;
+  border-color: #eea236;
+}
 button.cancel {
   margin-right: 10px;
 }

--- a/app/components/styleditor/tools/icons.modal.tpl.html
+++ b/app/components/styleditor/tools/icons.modal.tpl.html
@@ -6,7 +6,14 @@
             </div>
             <div class="col-xs-6">
               <button class="btn btn-default btn-sm cancel pull-right" ng-click="close()">Cancel</button>
-              <button id="copyIcon" class="btn btn-warning btn-sm pull-right" ng-click="ok()">Copy Selected to Clipboard</button>
+              <button ng-show="hasFlash" id="copyIcon" class="btn btn-warning btn-sm pull-right" ng-click="copy()">Copy Selected to Clipboard</button>
+			  <button ng-show="!hasFlash" id="copyDisabled" class="btn btn-warning btn-sm pull-right" 
+			    popover-trigger="mouseenter" popover-placement="bottom"
+                popover-append-to-body="true" popover-popup-delay="400"
+                popover="Install or enable Adobe Flash to support clipboard integration."
+				>
+				  Copy Selected to Clipboard
+				</button>
             </div>
         </div>
     </div>


### PR DESCRIPTION
ZeroClipboard (which allows modification of the clipboard on click events) requres Flash to function. This PR 'disables' the copy to clipbard button if flash is not installed, and adds tooltip text indicating that flash is required.
