### PR TITLE
Importer - Support more data types.

### DIFF
--- a/app/workspaces/detail/data.js
+++ b/app/workspaces/detail/data.js
@@ -457,12 +457,14 @@ angular.module('gsApp.workspaces.data', [
     } else if (store.kind.toLowerCase() === 'raster') {
       store.sourcetype = 'raster';
       store.displayName = store.name + ' (raster)';
-    } else if (store.type.toLowerCase() === 'database') {
+    } else if (store.type.toLowerCase() === 'database' || store.type.toLowerCase() === 'generic') {
       store.sourcetype = 'database';
       store.displayName = store.name + ' (database)';
     } else if (format.indexOf('directory of spatial files')!==-1) {
       store.sourcetype = 'shp_dir';
       store.displayName = store.name + ' (directory of shapefiles)';
+    } else if (store.type.toLowerCase() === 'web') {
+      store.sourcetype = 'web';
     }
     return store;
   };

--- a/app/workspaces/detail/data/data.main.tpl.html
+++ b/app/workspaces/detail/data/data.main.tpl.html
@@ -31,7 +31,7 @@
       <ul class="list-unstyled stores-list" ng-show="datastores && datastores.length > 0" ng-style="storesListHeight">
         <li class="store-row" ng-repeat="ds in datastores" ng-click="selectStore(ds);" ng-class="{'selected': ds.name==selectedStore.name}">
           <div class="icon-column" ng-click="getTypeDetails(ds);">
-            <h3 class="datastore-icons"><i ng-class="{'icon-file-4': ds.sourcetype=='shp', 'icon-folder-open': ds.sourcetype=='shp_dir', 'fa fa-database fa-md': ds.sourcetype=='database', 'icon-image-2': ds.sourcetype=='raster'}"></i></h3>
+            <h3 class="datastore-icons"><i ng-class="{'icon-file-4': ds.sourcetype=='shp', 'icon-folder-open': ds.sourcetype=='shp_dir', 'fa fa-database fa-md': ds.sourcetype=='database', 'icon-image-2': ds.sourcetype=='raster', 'icon-earth': ds.sourcetype=='web'}"></i></h3>
             <p class="datastore-label">{{ ds.sourcetype }}</p>
           </div>
           <div class="info-column">

--- a/app/workspaces/detail/data/import/import.db.tpl.html
+++ b/app/workspaces/detail/data/import/import.db.tpl.html
@@ -17,37 +17,54 @@
     </div>
   </div>
   <div ng-if="params" class="db-details">
-    <h3>{{format.description}}</h3>
+    <h3>{{format.title}}</h3>
+    <small>{{format.description}}</small>
     <form>
-      <div class="form-group" ng-if="params.host">
-        <div class="col-sm-10">
-          <label for="host">Host</label>
-          <input ng-model="params.host.value" name="host" type="text" class="form-control" focus-init>
+      <div class="db-format-db" ng-if="format.type.toLowerCase()=='database'">
+        <div class="form-group" ng-if="params.host">
+          <div class="col-sm-10">
+            <label for="host">Host</label>
+            <input ng-model="params.host.value" name="host" type="text" class="form-control" focus-init>
+          </div>
+          <div class="col-sm-2">
+            <label for="port">Port</label>
+            <input ng-model="params.port.value" name="port" type="text" class="form-control">
+          </div>
         </div>
-        <div class="col-sm-2">
-          <label for="port">Port</label>
-          <input ng-model="params.port.value" name="port" type="text" class="form-control">
+        <div class="form-group" ng-if="params.database">
+          <div class="col-sm-6">
+            <label for="database">Database</label>
+            <input ng-model="params.database.value" name="database" type="text" class="form-control">
+          </div>
+          <div class="col-sm-6" ng-if="params.schema">
+            <label for="schema">Schema</label>
+            <input ng-model="params.schema.value" name="schema" type="text" class="form-control">
+          </div>
+        </div>
+        <div class="form-group" ng-if="params.user">
+          <div class="col-sm-6">
+            <label for="user">Username</label>
+            <input ng-model="params.user.value" name="user" type="text" class="form-control">
+          </div>
+          <div class="col-sm-6">
+            <label for="passwd">Password</label>
+            <input ng-model="params.passwd.value" name="passwd" type="password" class="form-control">
+          </div>
         </div>
       </div>
-      <div class="form-group" ng-if="params.database">
-        <div class="col-sm-6">
-          <label for="database">Database</label>
-          <input ng-model="params.database.value" name="database" type="text" class="form-control">
+      <div class="db-format-generic" ng-if="format.type && format.type.toLowerCase()!='database'">
+        <div class="col-sm-12" ng-repeat="param in params">
+          <div class="form-group row" ng-if="param.required || param.level=='user'" ng-switch on="param.isPassword? 'password' : param.type.toLowerCase()">
+            <label ng-attr-title="{{param.description ? param.description:''}}" for="{param.title}">
+              {{ param.title }}
+            </label>
+            <span ng-if="param.required" style="color:red">*</span>
+            <input ng-switch-when="password" ng-model="param.value" name="{param.title}" class="form-control" type="password">
+            <input ng-switch-when="boolean" ng-model="param.value" name="{param.title}" class="form-control" type="checkbox" checked="{!!param.default}">
+            <input ng-switch-default ng-model="param.value" name="{param.title}" class="form-control" type="text" value="{param.default}">
+          </div>
         </div>
-        <div class="col-sm-6" ng-if="params.schema">
-          <label for="schema">Schema</label>
-          <input ng-model="params.schema.value" name="schema" type="text" class="form-control">
-        </div>
-      </div>
-      <div class="form-group" ng-if="params.user">
-        <div class="col-sm-6">
-          <label for="user">Username</label>
-          <input ng-model="params.user.value" name="user" type="text" class="form-control">
-        </div>
-        <div class="col-sm-6">
-          <label for="passwd">Password</label>
-          <input ng-model="params.passwd.value" name="passwd" type="password" class="form-control">
-        </div>
+        <div class="hint-required col-sm-12"><span style="color:red">*</span> Required</div>
       </div>
       <div class="form-group row">
         <div class="col-sm-12 text-center" style="margin-top: 20px;">

--- a/app/workspaces/detail/data/import/import.file.tpl.html
+++ b/app/workspaces/detail/data/import/import.file.tpl.html
@@ -1,11 +1,14 @@
 <div class="data-import-file">
   <div class="text-center">
     <p class="lead">
-      Upload one or more spatial files or .zip files<br/>containing any number of spatial files.
+      Upload one or more spatial files or .zip files<br/>containing any number of spatial files. 
+      <span popover-html-unsafe="{{fileTooltip}}" popover-trigger="click" popover-placement="bottom">
+        <i class="fa fa-info-circle"></i>
+      </span>
       <small>When uploading .shp files, remember to include .prj, .dbx, and .shx files.</small>
     </p>
 
-    <button class="btn btn-primary btn-sm" type="button"
+    <button class="btn btn-primary btn-sm browse-button" type="button"
       ng-file-select="onFileSelect($files)" data-multiple="true">
       Browse
     </button>

--- a/app/workspaces/detail/data/import/import.js
+++ b/app/workspaces/detail/data/import/import.js
@@ -315,7 +315,7 @@ angular.module('gsApp.workspaces.data.import', [
 
       storesListModel.getStores().forEach(function (store) {
         if (store.sourcetype == 'database' ||
-          store.sourcetype == 'shp_dir') {
+            store.sourcetype == 'shp_dir') {
           $scope.existingStores.push(store);
         }
       });
@@ -408,6 +408,24 @@ angular.module('gsApp.workspaces.data.import', [
       };
       $scope.initProgress();
 
+      GeoServer.formats.get().then(function(result) {
+        var fileTooltip = 
+          "<div class='data-import-file-tooltip'>" +
+          "<h5>Spatial Files</h5>" +
+          "<p>Supported file types:</p>";
+
+        if (result.success) {
+          result.data.forEach(function(f) {
+            if (f.type == 'file') {
+              fileTooltip += "<div class='file-type'><div><strong>"+f.title+"</strong></div>" +
+                                    "<div>"+f.description+"</div></div>"
+            }
+          });
+        }
+        fileTooltip += "</div>";
+        $scope.fileTooltip = fileTooltip;
+      });
+
     }])
 .controller('DataImportDbCtrl', ['$scope', '$state', '$stateParams', '$log',
     'GeoServer', '_', '$sce',
@@ -468,7 +486,7 @@ angular.module('gsApp.workspaces.data.import', [
       GeoServer.formats.get().then(function(result) {
         if (result.success) {
           $scope.formats = result.data.filter(function(f) {
-            return f.type == 'database';
+            return f.type == 'database' || f.type == 'generic';
           });
         }
       });

--- a/app/workspaces/detail/data/import/import.less
+++ b/app/workspaces/detail/data/import/import.less
@@ -45,6 +45,7 @@
 
   .browse-button {
     margin-bottom: 5px;
+    margin-left: 0px;
   }
 
   .file-list {
@@ -115,6 +116,22 @@
   }
 }
 
+.data-import-file-tooltip {
+  h5 {
+    padding-bottom: 10px;
+    border-bottom: 1px solid #E5E5E5;
+  }
+  p {
+    font-size: 13px;
+  }
+
+  .file-type {
+    margin-left: 15px;
+    margin-bottom: 5px;
+    font-size: 12px;
+  }
+}
+
 .data-import-db {
   .db-list {
     [class*="col-"] {
@@ -138,10 +155,24 @@
     margin-bottom: 30px;
   }
 
-/*   .db-details {
-  max-width: 70%;
-  margin: 0 auto;
-} */
+  .db-details {
+    .db-format-generic {
+      margin-left: 15px;
+      margin-top: 15px;
+
+      label[title]:not([title='']) {
+        border-bottom: 1px dotted @monacoblue;
+      }
+      input[type='checkbox'] {
+        width: 34px;
+      }
+      .hint-required {
+        padding-left: 0px;
+        //padding-top: 10px;
+        //border-top: 1px solid #E5E5E5;
+      }
+    }
+  } 
 }
 
 .data-import-details {


### PR DESCRIPTION
Add support for `type:generic` to db import (eg MongoDB, ArcSDE, ...)
Add list of supported files to file import as a tooltip.
Add icon for 'web' sources to stores list (Import not yet supported in composer).
'Generic' sources use DB icon.

Depends on https://github.com/boundlessgeo/suite/pull/962
