### PR TITLE
Made store name editable in composer

### DIFF
--- a/app/workspaces/detail/data.js
+++ b/app/workspaces/detail/data.js
@@ -160,6 +160,34 @@ angular.module('gsApp.workspaces.data', [
         });
       };
 
+      $scope.storeEdit = function (store, editing) {
+        if (editing) {
+          store.editing = true;
+          $timeout(function() {
+            $('.store-edit').focus();
+          }, 10);
+        } else {
+          store.refresh = true;
+          var newName = $('.store-edit').val();
+          GeoServer.datastores.update($scope.workspace, store.name, {name: newName})
+          .then(function(result) {
+            store.refresh = false;
+            if (result.success) {
+              store.name = result.data.name;
+              $scope.selectStore(store);
+            } else {
+              $rootScope.alerts = [{
+                type: 'warning',
+                message: 'Could not change store name from '+store.name+" to "+newName,
+                details: result.data.trace,
+                fadeout: true
+              }];
+            }
+          });
+          store.editing = false;
+        }
+      }
+
       $scope.dataLoading=true;
       $scope.serverRefresh().then(function() {
         $scope.dataLoading=false;

--- a/app/workspaces/detail/data/data.main.tpl.html
+++ b/app/workspaces/detail/data/data.main.tpl.html
@@ -35,7 +35,11 @@
             <p class="datastore-label">{{ ds.sourcetype }}</p>
           </div>
           <div class="info-column">
-            <p><strong>{{ ds.name }}</strong></p>
+            <div ng-if="!ds.editing" ng-click="storeEdit(ds, true)">
+              <strong>{{ ds.name }}</strong>
+              <span ng-show="ds.refresh"><i class="fa fa-spinner fa-spin"></i></span>
+            </div>
+            <div ng-if="ds.editing"><input class="store-edit" type="text" value="{{ds.name}}" ng-blur="storeEdit(ds, false)"></input></div>
             <div title="{{ ds.source }}" class="source-info" collapse="ds.name!=selectedStore.name">
               <strong>Location:</strong><span>{{ ds.source }}</span>
             </div>


### PR DESCRIPTION
Clicking on the store name in the data tab converts it to a text box, allowing editing of the store name.
