### PR TITLE
Use remote docs if local are not available

### DIFF
--- a/app/components/topnav/topnav.js
+++ b/app/components/topnav/topnav.js
@@ -39,4 +39,11 @@ angular.module('gsApp.topnav', ['gsApp.alertlist'])
         // - 
       }
       $scope.adminLink = GeoServer.baseUrl();
+
+      $scope.docUrl = '/opengeo-docs/'
+      GeoServer.docUrl().then(function (result) {
+        if (result.success && result.data.url) {
+          $scope.docUrl = result.data.url;
+        }
+      });
     }]);

--- a/app/components/topnav/topnav.tpl.html
+++ b/app/components/topnav/topnav.tpl.html
@@ -19,7 +19,7 @@
     <!-- Collect the nav links, forms, and other content for toggling -->
     <div class="collapse navbar-collapse" collapse="navCollapsed" id="collapse-items">
       <ul class="nav navbar-nav">
-        <li><a href="/opengeo-docs/webmaps/composer/" target="_blank">Help</a></li>
+        <li><a href="{{docUrl}}webmaps/composer/" target="_blank">Help</a></li>
         <li><a ng-click="errors()">Recent Alerts</a></li>
         <li ng-if="session.active" class="user dropdown" dropdown>
           <a class="dropdown-toggle" data-toggle="dropdown-user" dropdown-toggle>

--- a/app/index.html
+++ b/app/index.html
@@ -25,5 +25,6 @@
     <script type="text/javascript" src="ol.js"></script>
     <script type="text/javascript" src="codemirror.min.js"></script>
     <script type="text/javascript" src="geoserver.min.js"></script>
+    <script type="text/javascript" src="config.js"></script>
   </body>
 </html>

--- a/build.xml
+++ b/build.xml
@@ -4,6 +4,9 @@
     <exec executable="npm" failonerror="true">
        <arg line="install"/>
     </exec>
+
+    <replace file="build/config.js" value="${suite.version}" token="suite.version"/>
+
   </target>
 
   <target name="clean">

--- a/config.js
+++ b/config.js
@@ -1,0 +1,12 @@
+/*
+ * (c) 2014 Boundless, http://boundlessgeo.com
+ */
+/**
+ * Module containing configuration constants for the app. 
+ * Configured by build.xml, but only when built as part of OpenGeo Suite (https://github.com/boundlessgeo/suite), 
+ * as it depends on https://github.com/boundlessgeo/suite/blob/master/build/build.properties to set the suite version.
+ */
+angular.module('gsApp.config', [])
+.constant('AppConfig', {
+	SuiteVersion: 'suite.version'
+});

--- a/gruntfile.js
+++ b/gruntfile.js
@@ -231,6 +231,12 @@ module.exports = function(grunt) {
           src: prefixDeps(olDeps()),
           dest: 'build/'
         }]
+      },
+      config: {
+        files: [{
+          src: 'config.js',
+          dest: 'build/'
+        }]
       }
     },
     ngmin: {


### PR DESCRIPTION
Update topnav to link to remote (suite.opengeo.org) docs if local docs are not available (such as in a WAR install). Resolution tree is: {local} > {remote/version} > {remote/latest}
Add config.js for storing configurable properties
Modified build.xml to inject suite version into build.xml
